### PR TITLE
ci: add auto-merge job for specific PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,19 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  automerge:
+    needs: [lint, test, build, e2e]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'julwrites' && github.event.pull_request.base.ref == 'main'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Automerge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "$PR_URL" || true
+          gh pr merge --rebase --delete-branch "$PR_URL"


### PR DESCRIPTION
This PR adds an `automerge` job to `.github/workflows/ci.yml`. It will automatically approve and merge PRs authored by `julwrites` that target `main`, after passing the `lint`, `test`, `build`, and `e2e` jobs. This mirrors the functionality from the `webwiki` repository.

---
*PR created automatically by Jules for task [3500247304927743193](https://jules.google.com/task/3500247304927743193) started by @julwrites*