### PR TITLE
fix: enhance ExpenseForm UI layout and input initialization

### DIFF
--- a/components/ExpenseForm.vue
+++ b/components/ExpenseForm.vue
@@ -16,19 +16,6 @@
         />
       </UFormGroup>
 
-      <UFormGroup label="Category" name="category">
-        <USelectMenu
-          id="category"
-          v-model="expenseData.category"
-          :options="categoryOptions"
-          required
-          color="gray"
-          :ui="{ base: 'w-full' }"
-          @open="handleDropdownOpen"
-          @close="handleDropdownClose"
-        />
-      </UFormGroup>
-
       <UFormGroup label="Description" name="description" class="full-width-field">
         <USelectMenu
           id="description"
@@ -38,6 +25,19 @@
           required
           creatable
           searchable
+          color="gray"
+          :ui="{ base: 'w-full' }"
+          @open="handleDropdownOpen"
+          @close="handleDropdownClose"
+        />
+      </UFormGroup>
+
+      <UFormGroup label="Category" name="category">
+        <USelectMenu
+          id="category"
+          v-model="expenseData.category"
+          :options="categoryOptions"
+          required
           color="gray"
           :ui="{ base: 'w-full' }"
           @open="handleDropdownOpen"
@@ -96,10 +96,21 @@ const emits = defineEmits<{
   (event: 'cancel'): void;
 }>();
 
-const expenseData = ref<Expense>({
-  ...defaultExpense,
-  ...props.expense,
-});
+interface FormExpense extends Omit<Expense, 'credit' | 'debit'> {
+  credit: number | '';
+  debit: number | '';
+}
+
+const initExpenseData = (expense: Partial<Expense>): FormExpense => {
+  const merged = { ...defaultExpense, ...expense };
+  return {
+    ...merged,
+    credit: merged.credit === 0 ? '' : merged.credit,
+    debit: merged.debit === 0 ? '' : merged.debit,
+  };
+};
+
+const expenseData = ref<FormExpense>(initExpenseData(props.expense));
 
 const formKey = ref(0);
 const descriptionList = ref<{ label: string; category: string }[]>([]);
@@ -111,7 +122,7 @@ const toast = useToast();
 watch(
   () => props.expense,
   (newVal) => {
-    expenseData.value = { ...defaultExpense, ...newVal };
+    expenseData.value = initExpenseData(newVal);
   }
 );
 
@@ -148,17 +159,23 @@ onUnmounted(() => {
 });
 
 async function handleSubmit() {
-  if (validateExpense(expenseData.value)) {
+  const submitData: Expense = {
+    ...expenseData.value,
+    credit: expenseData.value.credit === '' ? 0 : Number(expenseData.value.credit),
+    debit: expenseData.value.debit === '' ? 0 : Number(expenseData.value.debit),
+  };
+
+  if (validateExpense(submitData)) {
     const isNewDescription = !descriptionList.value.some(
-      (d) => d.label === expenseData.value.description
+      (d) => d.label === submitData.description
     );
-    emits('submit', expenseData.value);
+    emits('submit', submitData);
     if (isNewDescription) {
       await fetchDescriptions();
     }
+    expenseData.value = initExpenseData(defaultExpense);
+    formKey.value++;
   }
-  expenseData.value = { ...defaultExpense };
-  formKey.value++;
 }
 
 function validateExpense(expense: Expense): boolean {
@@ -184,7 +201,7 @@ function validateExpense(expense: Expense): boolean {
 }
 
 function cancelEdit() {
-  expenseData.value = { ...defaultExpense }; // Reset form
+  expenseData.value = initExpenseData(defaultExpense); // Reset form
   emits('cancel');
 }
 

--- a/components/ExpenseForm.vue
+++ b/components/ExpenseForm.vue
@@ -16,7 +16,7 @@
         />
       </UFormGroup>
 
-      <UFormGroup label="Description" name="description" class="full-width-field">
+      <UFormGroup label="Description" name="description">
         <USelectMenu
           id="description"
           :key="formKey"
@@ -32,7 +32,7 @@
         />
       </UFormGroup>
 
-      <UFormGroup label="Category" name="category">
+      <UFormGroup label="Category" name="category" class="full-width-field">
         <USelectMenu
           id="category"
           v-model="expenseData.category"

--- a/tests/components/ExpenseFormReset.test.ts
+++ b/tests/components/ExpenseFormReset.test.ts
@@ -51,6 +51,6 @@ describe('ExpenseForm Reset', () => {
     expect(component.vm.expenseData.description).toBe('');
 
     // Check if other fields are reset
-    expect(component.vm.expenseData.debit).toBe(0);
+    expect(component.vm.expenseData.debit).toBe("");
   });
 });


### PR DESCRIPTION
This pull request introduces minor UI enhancements to the Expense Form:
- **Field Swap**: The `Description` field now appears before `Category`, improving the intuitive top-to-bottom flow since the Description often auto-selects the Category.
- **Improved Input UX**: The `Debit` and `Credit` fields previously defaulted to `0`, which caused issues when typing numbers (e.g. typing `4` resulted in `40`). We now initialize these fields as empty, and gracefully default them back to `0` on submission if left blank.

---
*PR created automatically by Jules for task [9603959558977000295](https://jules.google.com/task/9603959558977000295) started by @julwrites*